### PR TITLE
Add new envs for wiki path & queue page title

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,17 +10,19 @@ from utils import generate_auto_paragraph, generate_wiki_content, combine_conten
 load_dotenv()
 API_KEY = os.getenv('API_KEY')
 WIKI_URL = os.getenv('WIKI_URL')
+WIKI_PATH = os.getenv('WIKI_PATH')
 USERNAME = os.getenv('BOT_USERNAME')
 PASSWORD = os.getenv('BOT_PASSWORD')
+CHANNELS_PAGE_TITLE = os.getenv('CHANNELS_PAGE_TITLE')
+
+# Connect to MediaWiki
+site = connect_to_wiki(WIKI_URL, WIKI_PATH, USERNAME, PASSWORD)
 
 # Fetch the list of channels to update from the selected wiki page
-CHANNELS_TO_UPDATE = fetch_channels_needing_updates(WIKI_URL, 'User:YouTubeWikiBot/Filters/Channel Update Requests', USERNAME, PASSWORD)
+CHANNELS_TO_UPDATE = fetch_channels_needing_updates(site, CHANNELS_PAGE_TITLE)
 
 # Initialize YouTube client
 youtube = get_youtube_client(API_KEY)
-
-# Connect to MediaWiki
-site = connect_to_wiki(WIKI_URL, USERNAME, PASSWORD)
 
 # Iterate over each channel to update
 for channel_handle in CHANNELS_TO_UPDATE:

--- a/src/wiki_bot.py
+++ b/src/wiki_bot.py
@@ -2,9 +2,9 @@
 
 import mwclient
 
-def connect_to_wiki(wiki_url, username, password):
+def connect_to_wiki(wiki_url, wiki_path, username, password):
     """Connects to the MediaWiki site."""
-    site = mwclient.Site(wiki_url, path='/')
+    site = mwclient.Site(wiki_url, path=wiki_path)
     site.login(username, password)
     return site
 
@@ -19,11 +19,8 @@ def check_page_exists(site, page_title):
     page = site.pages[page_title]
     return page.exists, page.text()
 
-def fetch_channels_needing_updates(wiki_url, page_title, username, password):
-    # Connect to the MediaWiki site
-    site = mwclient.Site(wiki_url, path='/')
-    site.login(username, password)
-    
+def fetch_channels_needing_updates(site, page_title):
+    """Fetches the list of channels needing updates from the specified wiki page."""
     # Access the specified page
     page = site.pages[page_title]
     content = page.text()

--- a/tests/test_wiki_bot.py
+++ b/tests/test_wiki_bot.py
@@ -9,6 +9,7 @@ import os
 # Load environment variables
 load_dotenv()
 TEST_WIKI_URL = os.getenv('TEST_WIKI_URL')
+TEST_WIKI_PATH = os.getenv('TEST_WIKI_PATH')
 TEST_USERNAME = os.getenv('TEST_USERNAME')
 TEST_PASSWORD = os.getenv('TEST_PASSWORD')
 
@@ -24,10 +25,10 @@ def test_connect_to_wiki(mock_site):
     mock_site.login.return_value = True  # Mock successful login
 
     # Call the function with test settings
-    site = connect_to_wiki(TEST_WIKI_URL, TEST_USERNAME, TEST_PASSWORD)
+    site = connect_to_wiki(TEST_WIKI_URL, TEST_WIKI_PATH, TEST_USERNAME, TEST_PASSWORD)
 
     # Assertions
-    mock_site.assert_called_once_with(TEST_WIKI_URL, path='/')
+    mock_site.assert_called_once_with(TEST_WIKI_URL, path=TEST_WIKI_PATH)
     mock_site.login.assert_called_once_with(TEST_USERNAME, TEST_PASSWORD)
     assert site == mock_site
 
@@ -87,7 +88,7 @@ def test_fetch_channels_needing_updates_various(mock_site, page_text, expected_c
     mock_site.pages.__getitem__.return_value = mock_page  # Mock accessing the page
 
     # Call the function
-    channels = fetch_channels_needing_updates(TEST_WIKI_URL, 'Channel Update Requests', TEST_USERNAME, TEST_PASSWORD)
+    channels = fetch_channels_needing_updates(mock_site, 'Channel Update Requests')
 
     # Assertions
     mock_site.pages.__getitem__.assert_called_once_with('Channel Update Requests')


### PR DESCRIPTION
- Added new environment variables for wiki path and queue page title.
- Updated `src/main.py` to use the new environment variables.
- Modified `src/wiki_bot.py` to handle the new configuration.
- Adjusted `tests/test_wiki_bot.py` to test the new environment variables.

Fixes #3 and #4