### PR TITLE
Add URL of PyPI project entry in python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -56,7 +56,7 @@ jobs:
       #
       # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
       # ALTERNATIVE: exactly, uncomment the following line instead:
-      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+      url: https://pypi.org/project/YouTubeWikiBot/${{ github.event.release.name }}
 
     steps:
       - name: Retrieve release distributions


### PR DESCRIPTION
- Adds `url` of `environment` as PyPI website entry with version name as GitHub Release name.