### PR TITLE
Allow manual dispatch of package publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,7 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -49,14 +50,14 @@ jobs:
 
     # Dedicated environments with protections for publishing are strongly recommended.
     # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
-    environment:
-      name: pypi
+    # environment:
+      # name: pypi
       # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
       # url: https://pypi.org/p/YOURPROJECT
       #
       # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
       # ALTERNATIVE: exactly, uncomment the following line instead:
-      url: https://pypi.org/project/YouTubeWikiBot/${{ github.event.release.name }}
+      # url: https://pypi.org/project/YouTubeWikiBot/${{ github.event.release.name }}
 
     steps:
       - name: Retrieve release distributions


### PR DESCRIPTION
- Allow workflow_dispatch as option for publishing to the Python Packaging Index (PyPI).
- Remove the pypi dedicated environment, unnecessary for trusted publishing setup.
